### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     dirmult (>= 0.1.3-4),
     stats (>= 4.1.1),
     rlang (>= 0.2.0),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.0.0),
     stringr (>= 1.4.0),
     ggdag (>= 0.2.4),
@@ -38,8 +38,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppArmadillo,
     RcppEigen (>= 0.3.3.3.0),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 Suggests: 
     testthat,
     rmarkdown,

--- a/inst/stan/simplexes.stan
+++ b/inst/stan/simplexes.stan
@@ -14,28 +14,28 @@ int<lower=1> n_paths;
 int<lower=1> n_types;
 int<lower=1> n_param_sets;
 int<lower=1> n_nodes;
-int<lower=1> n_param_each[n_param_sets];
+array[n_param_sets] int<lower=1> n_param_each;
 int<lower=1> n_data;
 int<lower=1> n_events;
 int<lower=1> n_strategies;
 int<lower=0, upper=1> keep_transformed;
 
 vector<lower=0>[n_params] lambdas_prior;
-int<lower=1> l_starts[n_param_sets];
-int<lower=1> l_ends[n_param_sets];
+array[n_param_sets] int<lower=1> l_starts;
+array[n_param_sets] int<lower=1> l_ends;
 
-int<lower=1> node_starts[n_nodes];
-int<lower=1> node_ends[n_nodes];
+array[n_nodes] int<lower=1> node_starts;
+array[n_nodes] int<lower=1> node_ends;
 
-int<lower=1> strategy_starts[n_strategies];
-int<lower=1> strategy_ends[n_strategies];
+array[n_strategies] int<lower=1> strategy_starts;
+array[n_strategies] int<lower=1> strategy_ends;
 
 matrix[n_params, n_types] P;
 
 matrix[n_params, n_paths] parmap;
 matrix[n_paths, n_data] map;
 matrix<lower=0,upper=1>[n_events,n_data] E;
-int<lower=0> Y[n_events];
+array[n_events] int<lower=0> Y;
 
 }
 


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
