### PR TITLE
273 set prior bug

### DIFF
--- a/R/make_par_values.R
+++ b/R/make_par_values.R
@@ -299,9 +299,9 @@ make_par_values <- function(model,
 
     # check if conditions are under-specified
     if((length(x) != 1) & (length(commands) != length(names))) {
-      stop("A specified condition matches multiple parameters. If your model contains confounding your condition applies across multiple param_sets.
-           In these cases, it is unclear which value should be applied to which parameter. Try specifying the 'param_set' option to clarify which value should
-           be applied to which parameter.")
+      warning("A specified condition matches multiple parameters. In these cases it is unclear which parameter value should be assigned to which parameter. Assignment thus defaults to the order in which parameters appear in 'parameters_df'.
+              \n If your model contains confounding your condition may apply across multiple param_sets. In these cases you can clarify parameter assignment by specifying the 'param_set' option.
+              \n We advise checking that parameter assignment was carried out as you intended. ")
     }
 
     # ensure the unambiguous single value case passes checks

--- a/R/make_par_values.R
+++ b/R/make_par_values.R
@@ -304,7 +304,7 @@ make_par_values <- function(model,
     }
 
     # forgive user when specifying across
-    if(all(grepl("_", names)) && (length(x) != length(names))) {
+    if(all(grepl("_", names))) {
       warning("You are altering parameters on confounded nodes. Alterations will be applied across all 'param_sets'. If this is not the alteration behavior you intended, try specifying the 'param_set' option to more clearly indicate parameters whose values you wish to alter.")
       x <- rep(x, each = length(names)/length(commands))
     }

--- a/R/make_par_values.R
+++ b/R/make_par_values.R
@@ -306,7 +306,10 @@ make_par_values <- function(model,
     # forgive user when specifying across
     if(all(grepl("_", names))) {
       warning("You are altering parameters on confounded nodes. Alterations will be applied across all 'param_sets'. If this is not the alteration behavior you intended, try specifying the 'param_set' option to more clearly indicate parameters whose values you wish to alter.")
-      x <- rep(x, each = length(names)/length(commands))
+
+      if(length(x) != length(names)) {
+        x <- rep(x, each = length(names)/length(commands))
+      }
     }
 
     # ensure the unambiguous single value case passes checks

--- a/R/make_par_values.R
+++ b/R/make_par_values.R
@@ -297,11 +297,16 @@ make_par_values <- function(model,
       unlist()
 
 
-    # check if conditions are under-specified
+    # warn if conditions are under-specified
     if((length(x) != 1) & (length(commands) != length(names))) {
       warning("A specified condition matches multiple parameters. In these cases it is unclear which parameter value should be assigned to which parameter. Assignment thus defaults to the order in which parameters appear in 'parameters_df'.
-              \n If your model contains confounding your condition may apply across multiple param_sets. In these cases you can clarify parameter assignment by specifying the 'param_set' option.
               \n We advise checking that parameter assignment was carried out as you intended. ")
+    }
+
+    # forgive user when specifying across
+    if(all(grepl("_", names)) && (length(x) != length(names))) {
+      warning("You are altering parameters on confounded nodes. Alterations will be applied across all 'param_sets'. If this is not the alteration behavior you intended, try specifying the 'param_set' option to more clearly indicate parameters whose values you wish to alter.")
+      x <- rep(x, each = length(names)/length(commands))
     }
 
     # ensure the unambiguous single value case passes checks

--- a/R/set_restrictions.R
+++ b/R/set_restrictions.R
@@ -412,11 +412,12 @@ restrict_by_labels <- function(model,
 
   # If there are wild cards, spell them out
   if (wildcard) {
-    labels <-
-      lapply(labels, function(j)
-        unique(unlist(sapply(
-          j, unpack_wildcard
-        ))))
+    labels <- lapply(labels, function(j) {
+      sapply(j, unpack_wildcard) |>
+        unlist() |>
+        as.vector() |>
+        unique()
+    })
   }
 
   # Check if labels map to nodal types


### PR DESCRIPTION
`make_par_values` is now less strict. 

The following now simply warns about applying alterations to parameters in the order in which they appear in `parameters_df`

```
make_model("X -> Y; X <->Y") |> 
set_priors(node = "X", alphas = c(2,2))
```

When altering over confounded nodes behavior is now as follows: 

```
m <- make_model("X -> Y; X<->Y") |> 
  set_priors(node = "Y", nodal_type = c("01"), c(2,3))

m$parameters_df
```

Warns about applying alterations across `param_sets` and generates: 
```
   param_names node    gen param_set nodal_type given param_value priors
   <chr>       <chr> <int> <chr>     <chr>      <chr>       <dbl>  <dbl>
 1 X.0         X         1 X         0          ""           0.5       1
 2 X.1         X         1 X         1          ""           0.5       1
 3 Y.00_X.0    Y         2 Y.X.0     00         "X.0"        0.25      1
 4 Y.10_X.0    Y         2 Y.X.0     10         "X.0"        0.25      1
 5 Y.01_X.0    Y         2 Y.X.0     01         "X.0"        0.25      2
 6 Y.11_X.0    Y         2 Y.X.0     11         "X.0"        0.25      1
 7 Y.00_X.1    Y         2 Y.X.1     00         "X.1"        0.25      1
 8 Y.10_X.1    Y         2 Y.X.1     10         "X.1"        0.25      1
 9 Y.01_X.1    Y         2 Y.X.1     01         "X.1"        0.25      3
10 Y.11_X.1    Y         2 Y.X.1     11         "X.1"        0.25      1
```



```
m <- make_model("X -> Y; X<->Y") |> 
  set_priors(node = "Y", nodal_type = c("01","00"), c(2,3))

m$parameters_df
```

Warns about applying alterations across `param_sets` and generates:

```
   param_names node    gen param_set nodal_type given param_value priors
   <chr>       <chr> <int> <chr>     <chr>      <chr>       <dbl>  <dbl>
 1 X.0         X         1 X         0          ""           0.5       1
 2 X.1         X         1 X         1          ""           0.5       1
 3 Y.00_X.0    Y         2 Y.X.0     00         "X.0"        0.25      3
 4 Y.10_X.0    Y         2 Y.X.0     10         "X.0"        0.25      1
 5 Y.01_X.0    Y         2 Y.X.0     01         "X.0"        0.25      2
 6 Y.11_X.0    Y         2 Y.X.0     11         "X.0"        0.25      1
 7 Y.00_X.1    Y         2 Y.X.1     00         "X.1"        0.25      3
 8 Y.10_X.1    Y         2 Y.X.1     10         "X.1"        0.25      1
 9 Y.01_X.1    Y         2 Y.X.1     01         "X.1"        0.25      2
10 Y.11_X.1    Y         2 Y.X.1     11         "X.1"        0.25      1
```

