### PR TITLE
adds warnings when specifying non-linear queries

### DIFF
--- a/CausalQueries.Rproj
+++ b/CausalQueries.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: b4bac298-ab23-4e07-a211-3e6e4d95c675
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CausalQueries
 Type: Package
 Title: Make, Update, and Query Binary Causal Models
-Version: 1.3.3
+Version: 1.3.4
 Authors@R: c(person("Clara", "Bicalho", email = "clarabmcorreia@gmail.com", role = c("ctb")),
              person("Jasper", "Cooper", email = "jjc2247@columbia.edu", role = c("ctb")),
              person("Macartan", "Humphreys", email = "macartan@gmail.com", role = c("aut"),

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -456,6 +456,10 @@ check_query <- function(query) {
     }
   }
 
+  if(any(c("/", "^") %in% query)) {
+    non_linear_warn <- TRUE
+  }
+
   query <- paste(q, collapse = "")
 
   if (do_warn != 0) {
@@ -476,6 +480,16 @@ check_query <- function(query) {
         "some value should be specified with `==` not `=`. The query has been",
         "changed accordingly:",
         query,
+        sep = " "
+      )
+    )
+  }
+
+  if (non_linear_warn) {
+    warning(
+      paste(
+        "non-linear transformations e.g. / or ^ are not supported in querying.",
+        "Queries will output NaN or NA for estimates.",
         sep = " "
       )
     )
@@ -525,5 +539,7 @@ get_args_for <- function(fun, dots) {
 }
 
 
-has_posterior <- function(model)
+has_posterior <- function(model) {
   !is.null(model$posterior_distribution)
+}
+

--- a/R/make_models.R
+++ b/R/make_models.R
@@ -432,6 +432,17 @@ clean_statement <- function(statement) {
     )
   }
 
+  if (any(c("/", "^") %in% st_edge[!is_edge])) {
+    stop(
+      paste0(
+        "Unsupported characters in variable names. No '/' or '^' in variable names please.",
+        "\n",
+        "\n Adding mathematical operators describing non-linear transformations to variable names",
+        "\n will cause downstream issues when specifying queries."
+      )
+    )
+  }
+
   # counter that increments every time we hit an edge --> each character
   # belonging to a node thus has the same number (node_id)
   node_id <- cumsum(is_edge)


### PR DESCRIPTION
## Changes: 

- disallows non-linear query operators (/ and ^) in variable names >> implemented via `clean_statement()` in `make_model()`
- warns if any non-linear query operator (/ or ^) appears in a query >> implemented via `check_query()`

## Notes: 

- this approach is kind of aggressive / "dumb" since it simply checks if any non-linear operator appears anywhere in a query string 